### PR TITLE
prevent undefined in selected maplayers when changing view

### DIFF
--- a/bundles/asdi-projection-change/plugin/ProjectionChangerPlugin.js
+++ b/bundles/asdi-projection-change/plugin/ProjectionChangerPlugin.js
@@ -65,7 +65,10 @@ Oskari.clazz.define('Oskari.projection.change.ProjectionChangerPlugin',
                 url += window.location.pathname;
             }
             url += '?uuid=' + uuid;
-            url += this.getSelectedMapLayersUrlParam();
+            const selectedMapLayersParams = this.getSelectedMapLayersUrlParam();
+            if (selectedMapLayersParams && selectedMapLayersParams.length > 0) {
+                url += selectedMapLayersParams
+            }
 
             window.location.href = url;
         },

--- a/bundles/asdi-projection-change/plugin/ProjectionChangerPlugin.js
+++ b/bundles/asdi-projection-change/plugin/ProjectionChangerPlugin.js
@@ -67,7 +67,7 @@ Oskari.clazz.define('Oskari.projection.change.ProjectionChangerPlugin',
             url += '?uuid=' + uuid;
             const selectedMapLayersParams = this.getSelectedMapLayersUrlParam();
             if (selectedMapLayersParams && selectedMapLayersParams.length > 0) {
-                url += selectedMapLayersParams
+                url += selectedMapLayersParams;
             }
 
             window.location.href = url;
@@ -103,6 +103,7 @@ Oskari.clazz.define('Oskari.projection.change.ProjectionChangerPlugin',
                 el = this.getElement();
             };
             if (!el) return;
+            // eslint-disable-next-line react/no-deprecated
             ReactDOM.render(
                 <MapModuleButton
                     icon={<GlobalOutlined />}


### PR DESCRIPTION
changing projection in asdi when no map layers were selected resulted in 404 as maplayers url param was undefined.

![image](https://github.com/user-attachments/assets/57e99653-4191-46ad-9131-23e1435f01af) 

--------->

![image](https://github.com/user-attachments/assets/d718f043-a166-421a-8777-217f3ef72f71)

(not the same view in the screenshots but you get the idea 😛 )